### PR TITLE
All of these change previouly in v18

### DIFF
--- a/viz/com.raytheon.uf.viz.core/src/com/raytheon/uf/viz/core/localization/LocalizationConstants.java
+++ b/viz/com.raytheon.uf.viz.core/src/com/raytheon/uf/viz/core/localization/LocalizationConstants.java
@@ -29,6 +29,8 @@ package com.raytheon.uf.viz.core.localization;
  * Sep 24, 2008           chammack    Initial creation
  * Jun 03, 2014  3217     bsteffen    Add option to always open startup dialog.
  * Jun 24, 2014  3236     njensen     Add http server address options
+ * Jun 25, 2015          mjames@ucar  Added OAX as default site.
+ * Mar 25, 2019          mjames@ucar  URL prefix and suffix.
  * </pre>
  * 
  * @author chammack
@@ -51,10 +53,16 @@ public class LocalizationConstants {
 
     public static final String P_LOCALIZATION_PROMPT_ON_STARTUP = "promptOnStartup";
 
-    public static final String DEFAULT_LOCALIZATION_SERVER = "http://localhost:9581/services";
+    public static final String DEFAULT_LOCALIZATION_SERVER = "";
 
     public static final String DEFAULT_ALERT_SERVER = "tcp://localhost:61998";
 
     public static final String P_LOCALIZATION_HTTP_SERVER_OPTIONS = "httpServerAddressOptions";
+    
+    public static final String DEFAULT_LOCALIZATION_SITE = "OAX";
+    
+    public static final String LOCALIZATION_SERVER_PREFIX = "http://";
+    
+    public static final String LOCALIZATION_SERVER_SUFFIX = ":9581/services";
 
 }


### PR DESCRIPTION
ConnectivityManager
- add functionality for overriding IP resolution for edex connections

ConnectivityPreferenceDialog
- added in changes from MJ to simplify and clean up the server connection name
- added in changes from MJ to change the background/foreground colors to look nicer
- added in previous changes from me to have a checkbox for resolving edex ip addresses
- added in previous change from me so the dialog doesn't try to validate every time you type in the name field

LocalizationConstraints
- added in previous changes from MJ for cleaning up the server name
- added in prev MJ change for settin OAX as the default site